### PR TITLE
refactor: use default `shortenYAxisNumbers` feature

### DIFF
--- a/templates/chart.template
+++ b/templates/chart.template
@@ -80,6 +80,7 @@
       formatTooltipY: number => `${formatter.format(number)} doses`,
     },
     axisOptions: {
+      shortenYAxisNumbers: true,
       xIsSeries: true,
     },
     isNavigable: true,
@@ -130,6 +131,7 @@
       formatTooltipY: number => `${formatter.format(number)}%`,
     },
     axisOptions: {
+      shortenYAxisNumbers: true,
       xIsSeries: true,
     },
     isNavigable: true,
@@ -155,6 +157,7 @@
         formatTooltipY: number => `${formatter.format(number)} doses`,
       },
       axisOptions: {
+        shortenYAxisNumbers: true,
         xIsSeries: true,
       },
       isNavigable: true,
@@ -162,23 +165,4 @@
       height: 400,
     });
   <% } %>
-
-  // Work around https://github.com/frappe/charts/issues/322.
-  const fixLabels = () => {
-    const compactFormatter = new Intl.NumberFormat('en', {
-      notation: 'compact',
-    });
-    const labels = document.querySelectorAll('text[x="-10"]');
-    for (const label of labels) {
-      const number = Number(label.textContent);
-      label.textContent = compactFormatter.format(number);
-    }
-  };
-
-  // TODO: Use a mutation observer instead, if we can find a reliably
-  // detectable DOM modification that signals the charts are fully
-  // rendered.
-  setTimeout(() => {
-    fixLabels();
-  }, 1000);
 </script>


### PR DESCRIPTION
This PR replaces the DOM hack for formatting numbers with the available `shortenYAxisNumbers` option.

Here's a preview of the change

![image](https://user-images.githubusercontent.com/18097732/117426829-00241880-af42-11eb-9426-9328d4c33d22.png)


P.S. Thanks for creating such an amazing project, I'm glad you found Frappe Charts useful
